### PR TITLE
Update the game screen header before blocking on API call

### DIFF
--- a/mobile/Client/Client.iOS/Screens/GameViewController.cs
+++ b/mobile/Client/Client.iOS/Screens/GameViewController.cs
@@ -82,10 +82,12 @@ namespace Client.iOS
 		{
 			base.ViewWillAppear(animated);
 
-			await Presenter.OnBegin();
+			var updateTask = Presenter.OnBegin();
 
 			Header.AwayScore = Game.Score[0];
 			Header.HomeScore = Game.Score[1];
+
+			await updateTask;
 		}
 
 		public override void ViewWillDisappear(bool animated)


### PR DESCRIPTION
Before, it would wait for the score data to come in and then update the header. This way, the header is updated immediately (since the game information is local) and then the view is updated with the score history.

End result, the app feels significantly snappier